### PR TITLE
Changed keybinding

### DIFF
--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ define(function (require, exports, module) {
 
     AppInit.appReady(function () {
         console.log("[brackets-dash] init");
-        KeyBindingManager.addBinding(DASH_EXECUTE, "CTRL-ALT-H");
+        KeyBindingManager.addBinding(DASH_EXECUTE, "SHIFT-CMD-K");
 
     });
 


### PR DESCRIPTION
“extend” the Quick Docs keyboard shortcut (cmd/ctrl + K) by using
(cmd/ctrl + shift + K). This might be easier to remember.
See issue #1
